### PR TITLE
Fix timeout ttl

### DIFF
--- a/src/Limiter.php
+++ b/src/Limiter.php
@@ -144,10 +144,12 @@ class Limiter implements Contract
             return;
         }
 
+        $totalSeconds = $duration * 60;
+
         $this->cache->put(
             $this->getTimeoutKey(),
-            (int) $this->lastBucket()->timer() + ($duration * 60),
-            $duration
+            (int) $this->lastBucket()->timer() + $totalSeconds,
+            $totalSeconds
         );
     }
 


### PR DESCRIPTION
When timing out, the ttl should be at least as long as the timeout.

Please see #4