### PR TITLE
Fix TTL on hit()...

### DIFF
--- a/src/Limiter.php
+++ b/src/Limiter.php
@@ -161,7 +161,7 @@ class Limiter implements Contract
             $this->cache->put(
                 $bucket->key(),
                 $bucket->toArray(),
-                ceil($bucket->duration() / 60)
+                $bucket->remaining()
             );
         }
 


### PR DESCRIPTION
Related to #4 , #5 , and #6 .

This one wasn't as straightforward for me as I thought it would be.  I initially thought to pass `$bucket->duration()` for the TTL, but it seemed like it would **only** increase.

So...my confidence is a little low when it comes to this proposed change.  I believe it's wrong, but I'm not sure that this is the best fix.  It does seem to work according to my expectations, though, fwiw.

On a bit of a negative note, I now wonder what's going on with duration.  Why would duration continue to increase?  And, if it shouldn't be increasing, then what is impacted by that?