### PR TITLE
fix: timeout in seconds and correct usage of cache

### DIFF
--- a/src/Contracts/Limiter.php
+++ b/src/Contracts/Limiter.php
@@ -28,6 +28,13 @@ interface Limiter
     public function timeout(int $duration = 1): void;
 
     /**
+     * Limit additional hits for the duration in seconds.
+     *
+     * @param int $duration in seconds for the limit to take effect
+     */
+    public function timeoutInSeconds(int $duration = 1): void;
+
+    /**
      * Increment the counter for the rate limiter.
      */
     public function hit(): int;

--- a/src/Limiter.php
+++ b/src/Limiter.php
@@ -140,13 +140,23 @@ class Limiter implements Contract
      */
     public function timeout(int $duration = 1): void
     {
+        $this->timeoutInSeconds($duration * 60);
+    }
+
+    /**
+     * Limit additional hits for the duration in seconds.
+     *
+     * @param int $duration in seconds for the limit to take effect
+     */
+    public function timeoutInSeconds(int $duration = 1): void
+    {
         if ($this->hasTimeout()) {
             return;
         }
 
         $this->cache->put(
             $this->getTimeoutKey(),
-            (int) $this->lastBucket()->timer() + ($duration * 60),
+            (int) $this->lastBucket()->timer() + $duration,
             $duration
         );
     }
@@ -161,7 +171,7 @@ class Limiter implements Contract
             $this->cache->put(
                 $bucket->key(),
                 $bucket->toArray(),
-                ceil($bucket->duration() / 60)
+                $bucket->duration()
             );
         }
 


### PR DESCRIPTION
This PR fixes an issue with incorrect usage of the cache and adds a new `timeoutInSeconds` method to the limiter.