### PR TITLE
Fix cache key ttl

### DIFF
--- a/src/Limiter.php
+++ b/src/Limiter.php
@@ -161,7 +161,7 @@ class Limiter implements Contract
             $this->cache->put(
                 $bucket->key(),
                 $bucket->toArray(),
-                $bucket->duration()
+                max(1, $bucket->duration())
             );
         }
 

--- a/src/Limiter.php
+++ b/src/Limiter.php
@@ -161,7 +161,7 @@ class Limiter implements Contract
             $this->cache->put(
                 $bucket->key(),
                 $bucket->toArray(),
-                max(1, $bucket->duration())
+                $bucket->duration()
             );
         }
 

--- a/tests/LimiterTest.php
+++ b/tests/LimiterTest.php
@@ -63,10 +63,12 @@ class LimiterTest extends TestCase
     public function testExceeded()
     {
         $cache = new Cache();
-        $limiter = new Limiter($cache, new Leaky('default', 2, 1));
+        $limiter = new Limiter($cache, new Leaky('default', 2, 2));
 
         $limiter->hit();
         $this->assertFalse($limiter->exceeded(), 'The rate limiter should not be exceeded with 1 hit when the limit is 2.');
+
+        $limiter = new Limiter($cache, new Leaky('default', 2, 2));
 
         $limiter->hit();
         $this->assertTrue($limiter->exceeded(), 'The rate limiter should be exceeded with 2 hits when the limit is 2.');

--- a/tests/Stubs/Cache.php
+++ b/tests/Stubs/Cache.php
@@ -59,13 +59,22 @@ class Cache implements Repository
     /**
      * Store an item in the cache.
      *
-     * @param string                                     $key
-     * @param mixed                                      $value
-     * @param \DateTimeInterface|\DateInterval|float|int $minutes
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  \DateTimeInterface|\DateInterval|int|null  $ttl
+     * @return bool
      */
-    public function put($key, $value, $minutes = null)
+    public function put($key, $value, $ttl = null)
     {
+        $seconds = (int) $ttl;
+
+        if ($seconds <= 0) {
+            return $this->forget($key);
+        }
+
         $this->storage[$key] = $value;
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
With certain configurations of the limiter, the `$bucket->duration()` can result in a value lower than `1` which cache drivers can't handle, so this ensures a minimum of `1`